### PR TITLE
fix(action): set cache-dependency-path to action's pyproject.toml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,6 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.11"
-        cache: "pip"
-        cache-dependency-path: "${{ github.action_path }}/pyproject.toml"
 
     - name: Install
       run: pip install --quiet "${{ github.action_path }}"

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,7 @@ runs:
       with:
         python-version: "3.11"
         cache: "pip"
+        cache-dependency-path: "${{ github.action_path }}/pyproject.toml"
 
     - name: Install
       run: pip install --quiet "${{ github.action_path }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr_changes"
-version = "1.0.0"
+version = "1.0.1"
 description = "Build a matrix from a PR"
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
## Summary
- Fixes action failing in non-Python consumer repos (e.g. Docker image repos)
- `setup-python` with `cache: pip` searches the caller's workspace for `requirements.txt` or `pyproject.toml` by default — those files don't exist in non-Python repos
- Explicitly sets `cache-dependency-path` to `${{ github.action_path }}/pyproject.toml` so caching always resolves to the action's own dependency file

## Test plan
- [ ] Re-run [ZEFR-INC/docker#143](https://github.com/ZEFR-INC/docker/pull/143) after merging — `pr-changes` job should pass

---
```
(\__/)
(+'.'+)
(")_(")
```
Bunny helped with this PR and is one step closer to world domination...
